### PR TITLE
Refactor scalafix migration rewrite

### DIFF
--- a/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
@@ -132,7 +132,7 @@ case class SimplifyEitherTLift(index: SemanticdbIndex)
         .leading(t.tokens.head)
         .find(_.is[Token.Comma])
     } yield {
-      val leadingSpaces = ctx.tokenList.slice(leadingComma, t.tokens.last)
+      val leadingSpaces = ctx.tokenList.slice(leadingComma, t.tokens.head)
       ctx.removeToken(leadingComma) ++
         leadingSpaces.map(ctx.removeToken) +
         ctx.removeTokens(t.tokens)


### PR DESCRIPTION
- ctx.replaceSymbols also renames
- ctx.replaceSymbols also removes imports
- Tree.is[Comma] instead of `.syntax == ","`
- Tree.collectFirst/exists from contrib module.
- tokenList.leading().takeWhile to strip leading whitespace